### PR TITLE
Added IPinfo.io's API service

### DIFF
--- a/geo-ip-check/db_used.txt
+++ b/geo-ip-check/db_used.txt
@@ -4,6 +4,7 @@ AbstractAPI : https://app.abstractapi.com/#/
 IPregistry.com : https://dashboard.ipregistry.co/overview
 IPdata.co : https://dashboard.ipdata.co
 AstroIP: https://astroip.co/dashboard
+IPinfo : https://ipinfo.io/
 Maxmind : https://maxmind.com/  -  geoip2.webservice python module used
 RIPE, APNIC, ARIN, AFRINIC, LACNIB: IPwhois python module 
 

--- a/geo-ip-check/geo_class.py
+++ b/geo-ip-check/geo_class.py
@@ -76,6 +76,9 @@ class geo_data(parent_data):
         elif self.service == 'astroip':
             self.url = 'https://api.astroip.co/'+self.ip_address
 
+        elif self.service == 'ipinfo':
+            self.url = 'https://ipinfo.io/'+self.ip_address
+
         try:
             url = self.url
 
@@ -95,6 +98,9 @@ class geo_data(parent_data):
                 params = {'api-key' : self.apiKey}
 
             elif self.service == 'astroip':
+                params = dict(api_key=self.apiKey)
+            
+            elif self.service == 'ipinfo':
                 params = dict(api_key=self.apiKey)
 
             getInfo = requests.get(url=url, params=params)
@@ -212,6 +218,17 @@ class geo_data(parent_data):
                             'isp': ip_addr["asn"]["asn"] if (ip_addr["asn"] is not None) else '',
                             'latitude': ip_addr["geo"]["latitude"],
                             'longitude': ip_addr["geo"]["longitude"]}
+        
+        elif self.service == 'ipinfo':
+                geo_info = {'database': 'ipinfo.io',
+                            'code': ip_addr["country"],
+                            'country': '',
+                            'region': ip_addr["region"],
+                            'city': ip_addr["city"],
+                            'company': '',
+                            'isp': ip_addr["org"],
+                            'latitude': ip_addr["loc"].split(",")[0],
+                            'longitude': ip_addr["loc"].split(",")[1]}
 
 
 

--- a/geo-ip-check/geo_ip.py
+++ b/geo-ip-check/geo_ip.py
@@ -11,6 +11,7 @@ ipgeolocation_apiKey = ""
 abstractapi_apiKey = ""
 ipdata_apiKey = ""
 astroip_apiKey = ""
+ipinfo_apiKey = ""
 #XXXX below is the user account on maxmind webservice
 maxmind_user = XXXXX 
 maxmind_code = ""
@@ -35,6 +36,7 @@ ipregistry = ip.geo_data(ip_address, 'ipregistry', ipregistry_apiKey, cache)
 abstractapi = ip.geo_data(ip_address, 'abstractapi', abstractapi_apiKey, cache)
 ipdata = ip.geo_data(ip_address, 'ipdata', ipdata_apiKey, cache)
 astroip = ip.geo_data(ip_address, 'astroip', astroip_apiKey, cache)
+ipinfo = ip.geo_data(ip_address, 'ipinfo', ipinfo_apiKey, cache)
 
 data.append(maxmind.get_info())
 data.append(ip2location.get_info())
@@ -43,6 +45,7 @@ data.append(ipregistry.get_info())
 data.append(abstractapi.get_info())
 data.append(ipdata.get_info())
 data.append(astroip.get_info())
+data.append(ipinfo.get_info())
 
 
 print(f'''


### PR DESCRIPTION
I am requesting a review for the PR of adding [IPinfo's API service](https://ipinfo.io/).

The IPinfo API service provides:

- IP to Geolocation data
- 1,000 requests per day without an access token
- 50,000 requests per month with a [free tier access token](https://ipinfo.io/signup).

API request format:

```bash
curl ipinfo.io/188.80.206.XX
```

The payload format:

```json
{
    "ip": "188.80.206.XX",
    "hostname": "bl15-206-65.dsl.telepac.pt",
    "city": "Ansião",
    "region": "Leiria",
    "country": "PT",
    "loc": "39.9118,-8.4357",
    "org": "AS3243 MEO - SERVICOS DE COMUNICACOES E MULTIMEDIA S.A.",
    "postal": "3240-101",
    "timezone": "Europe/Lisbon",
    "readme": "https://ipinfo.io/missingauth"
}
```

---

Please let me know if you have any feedback. Thanks.